### PR TITLE
Fix SSL hostname verification failure in PullNotificationsTask

### DIFF
--- a/api/src/main/java/org/openmrs/module/xdssender/api/notificationspullpoint/impl/NotificationsPullPointClientImpl.java
+++ b/api/src/main/java/org/openmrs/module/xdssender/api/notificationspullpoint/impl/NotificationsPullPointClientImpl.java
@@ -49,6 +49,12 @@ import org.springframework.xml.transform.StringResult;
 import org.w3c.dom.Element;
 
 import ca.uhn.hl7v2.model.Message;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+import javax.net.ssl.SSLSocketFactory;
+import java.security.cert.X509Certificate;
+
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -162,7 +168,22 @@ public class NotificationsPullPointClientImpl extends WebServiceGatewaySupport i
 		StringResult result = new StringResult();
 		marshaller.marshal(requestPayload, result);
 
-		OkHttpClient client = new OkHttpClient().newBuilder().build();
+		OkHttpClient.Builder clientBuilder = new OkHttpClient().newBuilder();
+		if (config.getExportCcdIgnoreCerts()) {
+			final TrustManager[] trustAllCerts = new TrustManager[]{
+				new X509TrustManager() {
+					@Override public void checkClientTrusted(X509Certificate[] chain, String authType) {}
+					@Override public void checkServerTrusted(X509Certificate[] chain, String authType) {}
+					@Override public X509Certificate[] getAcceptedIssuers() { return new X509Certificate[]{}; }
+				}
+			};
+			SSLContext sslContext = SSLContext.getInstance("TLS");
+			sslContext.init(null, trustAllCerts, new java.security.SecureRandom());
+			SSLSocketFactory sslSocketFactory = sslContext.getSocketFactory();
+			clientBuilder.sslSocketFactory(sslSocketFactory, (X509TrustManager) trustAllCerts[0]);
+			clientBuilder.hostnameVerifier((hostname, session) -> true);
+		}
+		OkHttpClient client = clientBuilder.build();
 		MediaType mediaType = MediaType.parse("text/xml; charset=utf-8");
 		String facilitySiteCode = requestPayload.getOtherAttributes().get(new QName(FACILITY_QNAME));
 		String sinceAttribute = StringUtils.isNotBlank(lastRequestDate) && isValidISODate(lastRequestDate) ? String.format("since=\"%s\"", lastRequestDate)


### PR DESCRIPTION
## Problem
The `OkHttpClient` in `NotificationsPullPointClientImpl.getResponseHttpClient()` is created with default SSL configuration:

```java
OkHttpClient client = new OkHttpClient().newBuilder().build();
```

When the `PullNotificationsTask` connects to the OpenHIM endpoint (e.g., `https://openhim.sedish-haiti.org/dsub`), the DNS may resolve to an intermediary (load balancer, reverse proxy, CDN) that presents its own SSL certificate. The default `OkHttpClient` performs hostname verification — it checks that the certificate's CN/SAN matches the requested hostname. When they don't match, it throws:

```
SSLPeerUnverifiedException: Hostname openhim.sedish-haiti.org not verified:
    certificate: CN=lfcsdp.cell-1.prod.eu-central-1.prod.connect.aws.a2z.com
```

This fires every hour on the scheduled task and blocks all pull notifications.

## Fix
When the existing `xdssender.exportCcd.ignoreCerts` global property is `true`, configure the `OkHttpClient` with:
- A `TrustManager` that accepts all certificates (skips chain validation)
- A `HostnameVerifier` that accepts any hostname (skips CN/SAN matching)

This matches the behavior already available for CCD export via `XdsRetriever`, which uses `AllowAllHostnameVerifier` when the same property is set.

**Note:** This is a workaround for environments where the SSL certificate does not match the hostname. The proper long-term fix is to ensure the certificate presented at the endpoint matches the configured hostname.

## Changes
One file: `NotificationsPullPointClientImpl.java`

🤖 Generated with [Claude Code](https://claude.com/claude-code)