### PR TITLE
Skip XDS export cleanly when exportCcdEndpoint is blank

### DIFF
--- a/api/src/main/java/org/openmrs/module/xdssender/api/cda/EncounterEventListener.java
+++ b/api/src/main/java/org/openmrs/module/xdssender/api/cda/EncounterEventListener.java
@@ -66,6 +66,19 @@ public class EncounterEventListener implements EventListener {
 
 				if (CREATED.equals(messageAction) || UPDATED.equals(messageAction)) {
 					LOGGER.debug("Encounter event detected");
+
+					// If no export endpoint is configured, the module is effectively disabled:
+					// skip the export cleanly instead of letting getExportCcdEndpoint() throw an
+					// APIException on every encounter (which is only swallowed by the XDS.b error
+					// handler, producing noise and error-queue growth). Mirrors the
+					// mpi-client.endpoint.cr.addr guard in santedb-mpiclient.
+					String exportCcdEndpoint = Context.getAdministrationService()
+							.getGlobalProperty("xdssender.exportCcdEndpoint");
+					if (exportCcdEndpoint == null || exportCcdEndpoint.trim().isEmpty()) {
+						LOGGER.info("xdssender.exportCcdEndpoint is blank - XDS export disabled, skipping");
+						return;
+					}
+
 					String uuid = ((MapMessage) message).getString("uuid");
 					List<String> encounterTypesToProcess;
 					String propEncounterTypesToProcess = Context.getAdministrationService()


### PR DESCRIPTION
## Problem
`XdsSenderConfig.getExportCcdEndpoint()` reads the property with `getProperty(name)` (no default), which throws `APIException("Property value … is not set")` when the property is blank.

So when a deployment has **no** export endpoint configured, every CREATED/UPDATED encounter event throws during export. The exception is only caught by the XDS.b error handler (or rethrown as a `RuntimeException` when none is configured) — i.e. a per-encounter error plus error-queue growth, with no clean way to switch the outbound CCD push off.

## Change
Guard `EncounterEventListener` at the top of the CREATED/UPDATED branch: if `xdssender.exportCcdEndpoint` is null/blank, log and `return` — skipping the export before any endpoint is read.

This mirrors `santedb-mpiclient`, where an empty `mpi-client.endpoint.cr.addr` cleanly disables the patient feed. It gives deployments a one-property off-switch for the XDS export (useful when patient/clinical ingestion is handled by another path).

## Behaviour
- No change when `exportCcdEndpoint` is configured.
- When blank: encounters are skipped quietly (info log) — no `APIException`, no error-queue entries.
- Listener stays async (JMS); the existing try/catch is unchanged.