### PR TITLE
feat(xds-sender): pull consolidated IPS for continuity of care

### DIFF
--- a/api/src/main/java/org/openmrs/module/xdssender/XdsSenderConfig.java
+++ b/api/src/main/java/org/openmrs/module/xdssender/XdsSenderConfig.java
@@ -67,6 +67,8 @@ public class XdsSenderConfig {
 
 	private static final String XDSSENDER_EXPORT_CCD_ENDPOINT = "xdssender.exportCcdEndpoint";
 
+	private static final String XDSSENDER_IPS_ENDPOINT = "xdssender.ipsEndpoint";
+
 	private static final String XDSSENDER_OSHR_USERNAME = "xdssender.oshr.username";
 
 	private static final String XDSSENDER_OSHR_PASSWORD = "xdssender.oshr.password";
@@ -179,6 +181,12 @@ public class XdsSenderConfig {
 	
 	public String getExportCcdEndpoint() {
 		return getProperty(XDSSENDER_EXPORT_CCD_ENDPOINT);
+	}
+
+	// Base URL of the consolidated IPS mediator (e.g. https://<openhim>/SHR/ips). Used to pull a
+	// patient's cross-facility summary by CRUID for continuity of care.
+	public String getIpsEndpoint() {
+		return getProperty(XDSSENDER_IPS_ENDPOINT);
 	}
 
 	public String getLocalPatientIdRoot() { return getProperty("mpi-client.pid.local"); }

--- a/api/src/main/java/org/openmrs/module/xdssender/api/service/CcdService.java
+++ b/api/src/main/java/org/openmrs/module/xdssender/api/service/CcdService.java
@@ -21,6 +21,9 @@ public interface CcdService {
 	@Transactional
 	Ccd downloadAndSaveCcd(Patient patient) throws XDSException;
 
+	@Transactional
+	Ccd downloadAndSaveIps(Patient patient);
+
 	@Transactional(readOnly = true)
 	void downloadCcdAsPDF(OutputStream stream, Patient patient);
 }

--- a/api/src/main/java/org/openmrs/module/xdssender/api/service/impl/CcdServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/xdssender/api/service/impl/CcdServiceImpl.java
@@ -130,6 +130,20 @@ public class CcdServiceImpl implements CcdService {
     }
 
     @Override
+    public Ccd downloadAndSaveIps(Patient patient) {
+        Ccd ccd;
+
+        shrImportService.setFhirContext(fhirContext);
+        ccd = shrImportService.retrieveIps(patient);
+
+        if (ccd != null) {
+            ccd = ccdDao.saveOrUpdate(ccd);
+        }
+
+        return ccd;
+    }
+
+    @Override
     public void downloadCcdAsPDF(OutputStream stream, Patient patient) {
         LOGGER.info("CCD PDF is being downloaded.");
     }

--- a/api/src/main/java/org/openmrs/module/xdssender/api/service/impl/ShrImportServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/xdssender/api/service/impl/ShrImportServiceImpl.java
@@ -59,4 +59,29 @@ public class ShrImportServiceImpl implements XdsImportService {
 
 		return ccd;
 	}
+
+	/**
+	 * Retrieve the consolidated IPS document for a patient from the SHR IPS mediator and wrap it as
+	 * a Ccd (raw FHIR JSON), mirroring {@link #retrieveCCD(Patient)}. IPS document bundles carry no
+	 * total, so presence is judged by entries.
+	 */
+	public Ccd retrieveIps(Patient patient) {
+		Ccd ccd = null;
+		Bundle result;
+		try {
+			shrRetriever.setFhirContext(this.getFhirContext());
+			result = shrRetriever.fetchIps(patient);
+		} catch (Exception e) {
+			LOGGER.error("Unable to load IPS content", e);
+			return null;
+		}
+
+		if (result != null && result.hasEntry() && !result.getEntry().isEmpty()) {
+			ccd = new Ccd();
+			ccd.setPatient(patient);
+			ccd.setDocument(fhirContext.newJsonParser().encodeResourceToString(result));
+		}
+
+		return ccd;
+	}
 }

--- a/api/src/main/java/org/openmrs/module/xdssender/api/xds/ShrRetriever.java
+++ b/api/src/main/java/org/openmrs/module/xdssender/api/xds/ShrRetriever.java
@@ -27,6 +27,10 @@ public class ShrRetriever {
 
 	private static final String ECID_NAME = "ECID";
 
+	private static final String GOLDEN_RECORD_TAG = "5c827da5-4858-4f3d-a50c-62ece001efea";
+
+	private static final String ISANTEPLUS_ID_TYPE = "iSantePlus ID";
+
 	@Autowired
 	private XdsSenderConfig config;
 
@@ -139,6 +143,54 @@ public class ShrRetriever {
 		}
 		catch (Exception ex) {
 			LOGGER.error("Error when fetching ccd", ex);
+			return null;
+		}
+	}
+
+	/**
+	 * Pull the consolidated IPS for this patient from the SHR IPS mediator (continuity of care).
+	 * Resolves the patient's golden-record id (CRUID) from the MPI by iSantePlus ID, then GETs
+	 * {@code <ipsEndpoint>/Patient/cruid/<cruid>}. Returns null if no golden record resolves.
+	 */
+	public Bundle fetchIps(Patient patient) {
+		try {
+			IGenericClient mpiClient = getAuthenticatedClient(config.getMpiEndpoint(), config.getOshrUsername(),
+					config.getOshrPassword());
+
+			PatientIdentifier mpiIdentifier = patient.getPatientIdentifier(ISANTEPLUS_ID_TYPE);
+			if (mpiIdentifier == null) {
+				LOGGER.warn("Patient has no iSantePlus ID; cannot resolve CRUID for IPS retrieval");
+				return null;
+			}
+			String systemUrl = patientIdentifierSystemService.getUrlByPatientIdentifierType(mpiIdentifier.getIdentifierType());
+
+			Bundle linkedPatientBundle = mpiClient.search()
+					.byUrl("/Patient?identifier=" + systemUrl + "|" + mpiIdentifier.getIdentifier() + "&_include=Patient:link")
+					.returnBundle(Bundle.class).execute();
+
+			String cruid = null;
+			for (Bundle.BundleEntryComponent entry : linkedPatientBundle.getEntry()) {
+				if (entry.hasResource() && entry.getResource() instanceof org.hl7.fhir.r4.model.Patient) {
+					org.hl7.fhir.r4.model.Patient candidate = (org.hl7.fhir.r4.model.Patient) entry.getResource();
+					if (candidate.hasMeta() && candidate.getMeta().hasTag() && candidate.getMeta().getTagFirstRep().hasCode()
+							&& GOLDEN_RECORD_TAG.equals(candidate.getMeta().getTagFirstRep().getCode())) {
+						cruid = candidate.getIdElement().getIdPart();
+						break;
+					}
+				}
+			}
+
+			if (cruid == null) {
+				LOGGER.warn("No golden record (CRUID) resolved from MPI; cannot fetch IPS");
+				return null;
+			}
+
+			IGenericClient ipsClient = getAuthenticatedClient(config.getIpsEndpoint(), config.getOshrUsername(),
+					config.getOshrPassword());
+			return ipsClient.fetchResourceFromUrl(Bundle.class, config.getIpsEndpoint() + "/Patient/cruid/" + cruid);
+		}
+		catch (Exception ex) {
+			LOGGER.error("Error fetching IPS", ex);
 			return null;
 		}
 	}

--- a/omod/src/main/java/org/openmrs/module/xdssender/web/controller/IpsRetrievalController.java
+++ b/omod/src/main/java/org/openmrs/module/xdssender/web/controller/IpsRetrievalController.java
@@ -1,0 +1,56 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.xdssender.web.controller;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.openmrs.Patient;
+import org.openmrs.api.PatientService;
+import org.openmrs.module.xdssender.api.service.CcdService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+/**
+ * Continuity-of-care retrieval. Pulls a patient's consolidated IPS from the SHR IPS mediator
+ * (OpenCR resolves the patient to the golden record; OpenHIM aggregates the SHR clinical data) and
+ * returns it rendered for viewing. Read-only: it does not write discrete clinical data into the
+ * local record.
+ *
+ * <p>GET {@code module/xdssender/retrieveIps.form?patientId=<patientUuid>}
+ */
+@Controller("xdssender.IpsRetrievalController")
+@RequestMapping(value = "module/xdssender/retrieveIps.form")
+public class IpsRetrievalController {
+
+	protected final Log log = LogFactory.getLog(getClass());
+
+	@Autowired
+	private PatientService patientService;
+
+	@Autowired
+	private CcdService ccdService;
+
+	@RequestMapping(method = RequestMethod.GET)
+	@ResponseBody
+	public String retrieveIps(@RequestParam("patientId") String patientUuid) {
+		Patient patient = patientService.getPatientByUuid(patientUuid);
+		if (patient == null) {
+			log.warn("IPS retrieval requested for unknown patient uuid: " + patientUuid);
+			return "Patient not found: " + patientUuid;
+		}
+
+		ccdService.downloadAndSaveIps(patient);
+		return ccdService.getHtmlParsedLocallyStoredCcd(patient);
+	}
+}

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -91,6 +91,12 @@
 	</globalProperty>
 
 	<globalProperty>
+		<property>xdssender.ipsEndpoint</property>
+		<defaultValue>https://openhimcore.sedishtest.live/SHR/ips</defaultValue>
+		<description>Base URL of the consolidated IPS mediator used to pull a patient's cross-facility summary by CRUID (continuity of care)</description>
+	</globalProperty>
+
+	<globalProperty>
 		<property>xdssender.oshr.username</property>
 		<description>Specifies the OpenSHR username</description>
 	</globalProperty>


### PR DESCRIPTION
## What

Adds a **read-side retrieval** path so a site can fetch a patient's cross-facility summary (International Patient Summary) from SEDISH — the roaming / continuum-of-care flow. OpenCR resolves the patient to the golden record, OpenHIM aggregates the SHR clinical data, and the site displays it. **Read-only — it does not discretize data into the local record.**

## How

- **`ShrRetriever.fetchIps(patient)`** — resolves the patient's golden-record id (CRUID) from the MPI by iSantePlus ID, then GETs the consolidated IPS from the SHR IPS mediator (`/SHR/ips/Patient/cruid/<cruid>`) using the existing HAPI client + OpenHIM Basic auth.
- **`ShrImportServiceImpl.retrieveIps`** + **`CcdService.downloadAndSaveIps`** — wrap/persist the returned bundle (mirrors the existing CCD path).
- **`IpsRetrievalController`** — `GET module/xdssender/retrieveIps.form?patientId=<uuid>` fetches and renders the summary as HTML (reuses `XdsUtil.parseCcdToHtml`).
- **Config** — new `xdssender.ipsEndpoint` global property + `getIpsEndpoint()` (default `https://openhimcore.sedishtest.live/SHR/ips`).

Reuses the module's existing FHIR client, auth, config, and HTML renderer; the only net-new code is the IPS fetch + wiring (164 insertions, 0 deletions).

## Server side

Pairs with the SHR mediator's consolidated-IPS retrieval by CRUID / source-key / **fpnid**: DIGI-UW/shared-health-record#147.

## Follow-up (out of scope)

**Discretize + import** (writing IPS clinical resources as local Encounters/Observations/Conditions) is intentionally deferred — it's a larger, higher-risk mapper for a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)