### PR TITLE
Fix: pull-notifications endpoint is optional (unset must not abort module startup)

### DIFF
--- a/api/src/main/java/org/openmrs/module/xdssender/XdsSenderActivator.java
+++ b/api/src/main/java/org/openmrs/module/xdssender/XdsSenderActivator.java
@@ -36,7 +36,13 @@ public class XdsSenderActivator extends BaseModuleActivator {
 	public void started() {
 		log.info("Started Xds Sender");
 		Event.subscribe(Encounter.class, null, getEncounterEventListener());
-		Context.getRegisteredComponents(XdsSenderSchedulerServiceImpl.class).get(0).runXdsSenderScheduler();
+		// Never let optional scheduler/config setup abort module startup: log and continue.
+		try {
+			Context.getRegisteredComponents(XdsSenderSchedulerServiceImpl.class).get(0).runXdsSenderScheduler();
+		}
+		catch (Exception e) {
+			log.error("Unable to start the XDS Sender scheduler; continuing module startup without it", e);
+		}
 	}
 	
 	/**

--- a/api/src/main/java/org/openmrs/module/xdssender/XdsSenderConfig.java
+++ b/api/src/main/java/org/openmrs/module/xdssender/XdsSenderConfig.java
@@ -226,7 +226,9 @@ public class XdsSenderConfig {
 	}
 
 	public String getNotificationsPullPointEndpoint() {
-		return getProperty(NOTIFICATIONS_PULL_POINT_ENDPOINT);
+		// Optional feature: return null (rather than throwing) when unset so the scheduler
+		// simply skips the pull-notifications task instead of aborting module startup.
+		return getProperty(NOTIFICATIONS_PULL_POINT_ENDPOINT, null);
 	}
 
 	public String getNotificationsPullPointUsername() {


### PR DESCRIPTION
## Changes

**1. `api/.../XdsSenderConfig.java` — `getNotificationsPullPointEndpoint()`**
```diff
-    return getProperty(NOTIFICATIONS_PULL_POINT_ENDPOINT);          // throws APIException if unset
+    return getProperty(NOTIFICATIONS_PULL_POINT_ENDPOINT, null);    // returns null if unset
```
Use the non-throwing `getProperty(name, default)` so an unset endpoint returns `null` instead of throwing.

**2. `api/.../XdsSenderActivator.java` — `started()`**
```diff
-    Context.getRegisteredComponents(XdsSenderSchedulerServiceImpl.class).get(0).runXdsSenderScheduler();
+    try {
+        Context.getRegisteredComponents(XdsSenderSchedulerServiceImpl.class).get(0).runXdsSenderScheduler();
+    } catch (Exception e) {
+        log.error("Unable to start the XDS Sender scheduler; continuing module startup without it", e);
+    }
```
Wrap the scheduler bootstrap so no optional-config/scheduler error can abort module startup.

## Why these changes

`XdsSenderSchedulerServiceImpl.schedulePullNotificationsTask()` already guards for an unconfigured endpoint:
```java
String endpoint = config.getNotificationsPullPointEndpoint();
if (endpoint == null || endpoint.trim().isEmpty()) { /* log + skip */ return; }
```
…but change #1's throwing getter fired **before** the guard could run, so the guard was dead code. As a result, on any instance where `xdssender.notificationsPullPoint.endpoint` is not set, `started()` throws:
```
org.openmrs.api.APIException: Property value for 'xdssender.notificationsPullPoint.endpoint' is not set
    at XdsSenderConfig.getNotificationsPullPointEndpoint(XdsSenderConfig.java:229)
    at XdsSenderSchedulerServiceImpl.schedulePullNotificationsTask(...)
    at XdsSenderActivator.started(XdsSenderActivator.java:39)
```
The activator throws after `xds-sender.started=true` is written, so the module fails to finish starting and **every module that requires xds-sender cascades down** (registrationcore -> coreapps -> isanteplus -> ...). Change #1 makes the existing skip-guard work; change #2 is a safety net for any other scheduler/config failure.

## Behaviour: before vs after

| endpoint GP | before | after |
|---|---|---|
| unset | activator throws -> module + dependents fail to start | task skipped + logged, module starts |
| set    | task scheduled | task scheduled (unchanged) |
| set but scheduler errors | activator throws -> cascade | logged, module continues |

## Impact

Removes a mandatory, easy-to-forget, whole-EMR-fatal deploy prerequisite: the pull-notifications feature becomes truly optional (off when unconfigured) instead of crashing startup. No config or DB change required by this PR.